### PR TITLE
RoundChangeLifecycleStageEvent to implement the cancellable interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ defaultTasks 'clean', 'updateLicenses', 'build'
 
 // Project information
 group = 'net.caseif.flint'
-version = '1.3.1'
+version = '1.3.2'
 
 // Extended project information
 ext.projectName = 'flint'

--- a/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
+++ b/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
@@ -24,9 +24,10 @@
 
 package net.caseif.flint.event.round;
 
-import java.util.concurrent.Cancellable;
 import net.caseif.flint.round.LifecycleStage;
 import net.caseif.flint.round.Round;
+
+import java.util.concurrent.Cancellable;
 
 /**
  * Called when a {@link Round} changes its {@link LifecycleStage}.

--- a/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
+++ b/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
@@ -24,9 +24,9 @@
 
 package net.caseif.flint.event.round;
 
+import java.util.concurrent.Cancellable;
 import net.caseif.flint.round.LifecycleStage;
 import net.caseif.flint.round.Round;
-import java.util.concurrent.Cancellable;
 
 /**
  * Called when a {@link Round} changes its {@link LifecycleStage}.

--- a/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
+++ b/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
@@ -26,6 +26,7 @@ package net.caseif.flint.event.round;
 
 import net.caseif.flint.round.LifecycleStage;
 import net.caseif.flint.round.Round;
+import java.util.concurrent.Cancellable;
 
 /**
  * Called when a {@link Round} changes its {@link LifecycleStage}.
@@ -33,7 +34,7 @@ import net.caseif.flint.round.Round;
  * @author Max Roncace
  * @since 1.0
  */
-public interface RoundChangeLifecycleStageEvent extends RoundEvent {
+public interface RoundChangeLifecycleStageEvent extends RoundEvent, Cancellable {
 
     /**
      * Returns the {@link LifecycleStage} of the {@link Round} before the event.
@@ -50,5 +51,14 @@ public interface RoundChangeLifecycleStageEvent extends RoundEvent {
      * @since 1.0
      */
     LifecycleStage getStageAfter();
+    
+    /**
+     * Returns whether the {@link LifecycleStage} that came before the event completed
+     * due to the timer expiring.
+     *
+     * @return Whether the {@link LifeCycleStage} that came before the event completed
+     *     due to the timer expiring.
+     */
+    boolean isDone();
 
 }

--- a/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
+++ b/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java
@@ -58,6 +58,7 @@ public interface RoundChangeLifecycleStageEvent extends RoundEvent, Cancellable 
      *
      * @return Whether the {@link LifeCycleStage} that came before the event completed
      *     due to the timer expiring.
+     * @since 1.3.2
      */
     boolean isDone();
 


### PR DESCRIPTION
### Proposal

The [RoundChangeLifecycleStageEvent](https://github.com/caseif/Flint/blob/master/src/main/java/net/caseif/flint/event/round/RoundChangeLifecycleStageEvent.java) event should implement the `cancellable` interface in order to prevent the round from crossing over to the next stage in the life cycle. The current API restricts a stage to a single state of completion, this being the specified duration of time. It may be a need for some to perform other checks in order to determine whether or not the life cycle is completed.


### Consider this scenario
> You have a stage in your life cycle called "Lobby". During this stage, you may want to perform a check to determine the number of players that have currently joined the round. If the number of players are less than 6, you wish to reset the lobby timer, and wait for more players.

### Conclusion

Making this simple adjustment to the API would allow these types of scenarios to be carried out with very little effort.

